### PR TITLE
Added JSON string basic escaping

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	attrPrefix = "-"
+	// attrPrefix = "-"
+	attrPrefix = ""
 )
 
 // A Decoder reads and decodes XML objects from an input stream.

--- a/decoder.go
+++ b/decoder.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	// attrPrefix = "-"
-	attrPrefix = ""
+	attrPrefix = "-"
 )
 
 // A Decoder reads and decodes XML objects from an input stream.

--- a/encoder.go
+++ b/encoder.go
@@ -1,6 +1,9 @@
 package xml2json
 
-import "io"
+import (
+	"io"
+	"strings"
+)
 
 // An Encoder writes JSON objects to an output stream.
 type Encoder struct {
@@ -64,7 +67,7 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 	} else {
 		// TODO : Extract data type
 		enc.write("\"")
-		enc.write(n.Data)
+		enc.write(escapeJsonString(n.Data))
 		enc.write("\"")
 	}
 
@@ -73,4 +76,8 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 
 func (enc *Encoder) write(s string) {
 	enc.w.Write([]byte(s))
+}
+
+func escapeJsonString(s string) string {
+	return strings.Replace(s, "\"", "\\\"", -1)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -67,7 +67,7 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 	} else {
 		// TODO : Extract data type
 		enc.write("\"")
-		enc.write(escapeJsonString(n.Data))
+		enc.write(escapeJSONString(n.Data))
 		enc.write("\"")
 	}
 
@@ -78,6 +78,6 @@ func (enc *Encoder) write(s string) {
 	enc.w.Write([]byte(s))
 }
 
-func escapeJsonString(s string) string {
+func escapeJSONString(s string) string {
 	return strings.Replace(s, "\"", "\\\"", -1)
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -26,7 +26,8 @@ func TestEncode(t *testing.T) {
 		Misc: map[string]string{
 			"Nationality": "Swiss",
 			"City":        "Zürich",
-			"foo":         "\"quoted text\"",
+			"foo":         "",
+			"bar":         "\"quoted text\"",
 		},
 	}
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -79,3 +79,68 @@ func TestEncode(t *testing.T) {
 		assert.Equal(author.Misc[k], v)
 	}
 }
+
+// TestEscaping ensures that encode properly escapes double quotes in JSON strings
+func TestEscaping(t *testing.T) {
+	assert := assert.New(t)
+
+	author := bio{
+		Firstname: "Bastien",
+		Lastname:  "Gysler",
+		Hobbies:   []string{"DJ", "Running", "Tennis"},
+		Misc: map[string]string{
+			"Nationality": "Swiss",
+			"City":        "Zürich",
+			"foo":         "\"quoted text\"",
+		},
+	}
+
+	// Build document
+	root := &Node{}
+	root.AddChild("firstname", &Node{
+		Data: author.Firstname,
+	})
+	root.AddChild("lastname", &Node{
+		Data: author.Lastname,
+	})
+
+	for _, h := range author.Hobbies {
+		root.AddChild("hobbies", &Node{
+			Data: h,
+		})
+	}
+
+	misc := &Node{}
+	for k, v := range author.Misc {
+		misc.AddChild(k, &Node{
+			Data: v,
+		})
+	}
+	root.AddChild("misc", misc)
+
+	// Convert to JSON string
+	buf := new(bytes.Buffer)
+	err := NewEncoder(buf).Encode(root)
+	if err != nil {
+		assert.NoError(err)
+	}
+
+	// Build SimpleJSON
+	sj, err := sj.NewJson(buf.Bytes())
+	res, err := sj.Map()
+	assert.NoError(err)
+
+	// Assertions
+	assert.Equal(author.Firstname, res["firstname"])
+	assert.Equal(author.Lastname, res["lastname"])
+
+	resHobbies, err := sj.Get("hobbies").StringArray()
+	assert.NoError(err)
+	assert.Equal(author.Hobbies, resHobbies)
+
+	resMisc, err := sj.Get("misc").Map()
+	assert.NoError(err)
+	for k, v := range resMisc {
+		assert.Equal(author.Misc[k], v)
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -15,73 +15,8 @@ type bio struct {
 	Misc      map[string]string
 }
 
-// TestEncode ensures that encode outputs the expected JSON document
+// TestEncode ensures that encode outputs the expected JSON document.
 func TestEncode(t *testing.T) {
-	assert := assert.New(t)
-
-	author := bio{
-		Firstname: "Bastien",
-		Lastname:  "Gysler",
-		Hobbies:   []string{"DJ", "Running", "Tennis"},
-		Misc: map[string]string{
-			"Nationality": "Swiss",
-			"City":        "Zürich",
-			"foo":         "",
-		},
-	}
-
-	// Build document
-	root := &Node{}
-	root.AddChild("firstname", &Node{
-		Data: author.Firstname,
-	})
-	root.AddChild("lastname", &Node{
-		Data: author.Lastname,
-	})
-
-	for _, h := range author.Hobbies {
-		root.AddChild("hobbies", &Node{
-			Data: h,
-		})
-	}
-
-	misc := &Node{}
-	for k, v := range author.Misc {
-		misc.AddChild(k, &Node{
-			Data: v,
-		})
-	}
-	root.AddChild("misc", misc)
-
-	// Convert to JSON string
-	buf := new(bytes.Buffer)
-	err := NewEncoder(buf).Encode(root)
-	if err != nil {
-		assert.NoError(err)
-	}
-
-	// Build SimpleJSON
-	sj, err := sj.NewJson(buf.Bytes())
-	res, err := sj.Map()
-	assert.NoError(err)
-
-	// Assertions
-	assert.Equal(author.Firstname, res["firstname"])
-	assert.Equal(author.Lastname, res["lastname"])
-
-	resHobbies, err := sj.Get("hobbies").StringArray()
-	assert.NoError(err)
-	assert.Equal(author.Hobbies, resHobbies)
-
-	resMisc, err := sj.Get("misc").Map()
-	assert.NoError(err)
-	for k, v := range resMisc {
-		assert.Equal(author.Misc[k], v)
-	}
-}
-
-// TestEscaping ensures that encode properly escapes double quotes in JSON strings
-func TestEscaping(t *testing.T) {
 	assert := assert.New(t)
 
 	author := bio{


### PR DESCRIPTION
Basic escaping is mandatory to correctly handle situations like `<node>some "quoted" text</node>`
```
func Test() {
	xml := strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?><hello>world { "a": "b", "c": ["d", "e"] }</hello>`)

	if jsonBuffer, err := xml2json.Convert(xml); err == nil {
		log.Print(jsonBuffer)

		var obj interface{}

		err := json.Unmarshal(jsonBuffer.Bytes(), &obj)

		if err != nil {
			panic(err)
		}

		log.Print(obj)
	}
}
```