### PR TITLE
Update decoder.go

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -58,7 +58,9 @@ func (dec *Decoder) Decode(root *Node) error {
 			}
 		case xml.CharData:
 			// Extract XML data (if any)
-			elem.n.Data = string(xml.CharData(se))
+			if len(elem.n.Data) == 0 || len(string(xml.CharData(se))) > len(elem.n.Data) {
+				elem.n.Data = string(xml.CharData(se))
+			}
 		case xml.EndElement:
 			// And add it to its parent list
 			if elem.parent != nil {


### PR DESCRIPTION
当处理字符数据，并字符数据是 <![CDATA[]]>节点且<![CDATA[]]>和标签不在同一行时，解析会有问题；forexample:
<?xml version="1.0" encoding="utf-8"?>
<ioc>
    <id>RANSOME_0001</id>
    <short_description>勒索者</short_description>
    <description>勒索者描述</description>
    <authored_by>360</authored_by>
    <timestamp>2016-5-12 16:13:31</timestamp>
    <version>1.0</version>
    <overview>
        <![CDATA[洋葱狗 ]]>
    </overview>
</ioc>
解析上面这个的时候，overview 结果就会是一个换行。
我修改之后，能解决这个问题