### PR TITLE
Fix for XML strings ending with a rune

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -88,7 +88,7 @@ func trimNonGraphic(s string) string {
 
 	var first *int
 	var last int
-	for i, r := range s {
+	for i, r := range []rune(s) {
 		if !unicode.IsGraphic(r) || unicode.IsSpace(r) {
 			continue
 		}
@@ -107,5 +107,5 @@ func trimNonGraphic(s string) string {
 		return ""
 	}
 
-	return s[*first : last+1]
+	return string([]rune(s)[*first : last+1])
 }

--- a/decoder.go
+++ b/decoder.go
@@ -88,7 +88,7 @@ func trimNonGraphic(s string) string {
 
 	var first *int
 	var last int
-	for i, r := range []rune(s) {
+	for i, r := range s {
 		if !unicode.IsGraphic(r) || unicode.IsSpace(r) {
 			continue
 		}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -45,6 +45,7 @@ func TestTrim(t *testing.T) {
 		{in: "", expected: ""},
 		{in: "\n", expected: ""},
 		{in: "\n\v", expected: ""},
+		{in: "ending with ä", expected: "ending with ä"},
 	}
 
 	for _, scenario := range table {


### PR DESCRIPTION
If string ended with multibyte runes, they were getting cut with the original implementation, this PR fixes that.