### PR TITLE
Loop through runes to get indices right

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -88,7 +88,7 @@ func trimNonGraphic(s string) string {
 
 	var first *int
 	var last int
-	for i, r := range s {
+	for i, r := range []rune(s) {
 		if !unicode.IsGraphic(r) || unicode.IsSpace(r) {
 			continue
 		}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -46,6 +46,7 @@ func TestTrim(t *testing.T) {
 		{in: "\n", expected: ""},
 		{in: "\n\v", expected: ""},
 		{in: "ending with ä", expected: "ending with ä"},
+		{in: "ä and ä", expected: "ä and ä"},
 	}
 
 	for _, scenario := range table {


### PR DESCRIPTION
Need to loop through runes to get the index number right, as it's used in the later logic.

The number of iterations is correct with string, but the index gets shifted due to the multibyte nature. Example here: https://play.golang.org/p/GUaBKqikq9