### PR TITLE
Support for blank prefixes

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -54,13 +54,6 @@ func NewDecoder(r io.Reader) *Decoder {
 // input and stores it in the value pointed to by v.
 func (dec *Decoder) Decode(root *Node) error {
 
-	if dec.contentPrefix == "" {
-		dec.contentPrefix = contentPrefix
-	}
-	if dec.attributePrefix == "" {
-		dec.attributePrefix = attrPrefix
-	}
-
 	xmlDec := xml.NewDecoder(dec.r)
 
 	// That will convert the charset if the provided XML is non-UTF-8

--- a/decoder.go
+++ b/decoder.go
@@ -43,7 +43,11 @@ func (dec *Decoder) DecodeWithCustomPrefixes(root *Node, contentPrefix string, a
 
 // NewDecoder returns a new decoder that reads from r.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+	return &Decoder{
+		r:               r,
+		attributePrefix: attrPrefix,
+		contentPrefix:   contentPrefix,
+	}
 }
 
 // Decode reads the next JSON-encoded value from its

--- a/encoder.go
+++ b/encoder.go
@@ -16,7 +16,11 @@ type Encoder struct {
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w: w}
+	return &Encoder{
+		w:               w,
+		contentPrefix:   contentPrefix,
+		attributePrefix: attrPrefix,
+	}
 }
 
 func (enc *Encoder) SetAttributePrefix(prefix string) {
@@ -40,12 +44,6 @@ func (enc *Encoder) Encode(root *Node) error {
 	}
 	if root == nil {
 		return nil
-	}
-	if enc.contentPrefix == "" {
-		enc.contentPrefix = contentPrefix
-	}
-	if enc.attributePrefix == "" {
-		enc.attributePrefix = attrPrefix
 	}
 
 	enc.err = enc.format(root, 0)


### PR DESCRIPTION
My prior fix doesn't support blank prefixes, since it will default when blank, now during NewDecoder/NewEncoder the default encoder values are set.