### PR TITLE
Improved plugin system + added new plugins and type

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -6,20 +6,17 @@ import (
 )
 
 // Convert converts the given XML document to JSON
-func Convert(r io.Reader, ps ...encoderPlugin) (*bytes.Buffer, error) {
+func Convert(r io.Reader, ps ...plugin) (*bytes.Buffer, error) {
 	// Decode XML document
 	root := &Node{}
-	err := NewDecoder(r).Decode(root)
+	err := NewDecoder(r, ps...).Decode(root)
 	if err != nil {
 		return nil, err
 	}
 
 	// Then encode it in JSON
 	buf := new(bytes.Buffer)
-	e := NewEncoder(buf)
-	for _, p := range ps {
-		e = p.AddTo(e)
-	}
+	e := NewEncoder(buf, ps...)
 	err = e.Encode(root)
 	if err != nil {
 		return nil, err

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -7,11 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestDecode ensures that decode does not return any errors (not that useful)
-func TestDecode(t *testing.T) {
-	assert := assert.New(t)
-
-	s := `<?xml version="1.0" encoding="UTF-8"?>
+var s = `<?xml version="1.0" encoding="UTF-8"?>
   <osm version="0.6" generator="CGImap 0.0.2">
    <bounds minlat="54.0889580" minlon="12.2487570" maxlat="54.0913900" maxlon="12.2524800"/>
    <node id="298884269" lat="54.0901746" lon="12.2482632" user="SvenHRO" uid="46882" visible="true" version="1" changeset="676636" timestamp="2008-09-21T21:37:45Z"/>
@@ -22,6 +18,10 @@ func TestDecode(t *testing.T) {
    </node>
    <foo>bar</foo>
   </osm>`
+
+// TestDecode ensures that decode does not return any errors (not that useful)
+func TestDecode(t *testing.T) {
+	assert := assert.New(t)
 
 	// Decode XML document
 	root := &Node{}
@@ -36,6 +36,28 @@ func TestDecode(t *testing.T) {
 	err = dec.DecodeWithCustomPrefixes(root, "test3", "test4")
 	assert.NoError(err)
 
+}
+
+func TestDecodeWithoutDefaultsAndSomeAttributes(t *testing.T) {
+	assert := assert.New(t)
+
+	// Decode XML document
+	root := &Node{}
+	var err error
+	var dec *Decoder
+	dec = NewDecoder(strings.NewReader(s))
+	dec.TurnOffDefaultPrefixes()
+	dec.ExcludeAttributes([]string{"version", "generator"})
+	err = dec.Decode(root)
+	assert.NoError(err)
+
+	// Check that some attribute`s name has no prefix and has expected value
+	assert.Exactly(root.Children["osm"][0].Children["bounds"][0].Children["minlat"][0].Data, "54.0889580")
+	// Check that some attributes are not present
+	_, exists := root.Children["osm"][0].Children["version"]
+	assert.False(exists)
+	_, exists = root.Children["osm"][0].Children["generator"]
+	assert.False(exists)
 }
 
 func TestTrim(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -38,16 +38,14 @@ func TestDecode(t *testing.T) {
 
 }
 
-func TestDecodeWithoutDefaultsAndSomeAttributes(t *testing.T) {
+func TestDecodeWithoutDefaultsAndExcludeAttributes(t *testing.T) {
 	assert := assert.New(t)
 
 	// Decode XML document
 	root := &Node{}
 	var err error
 	var dec *Decoder
-	dec = NewDecoder(strings.NewReader(s))
-	dec.TurnOffDefaultPrefixes()
-	dec.ExcludeAttributes([]string{"version", "generator"})
+	dec = NewDecoder(strings.NewReader(s), WithAttrPrefix(""), ExcludeAttributes([]string{"version", "generator"}))
 	err = dec.Decode(root)
 	assert.NoError(err)
 

--- a/encoder.go
+++ b/encoder.go
@@ -2,7 +2,6 @@ package xml2json
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"unicode/utf8"
 )
@@ -102,7 +101,6 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 		if enc.tc == nil {
 			// do nothing
 		} else {
-			fmt.Println(s)
 			s = enc.tc.Convert(s)
 		}
 		enc.write(s)

--- a/encoder.go
+++ b/encoder.go
@@ -16,10 +16,10 @@ type Encoder struct {
 }
 
 // NewEncoder returns a new encoder that writes to w.
-func NewEncoder(w io.Writer, plugins ...encoderPlugin) *Encoder {
-	e := &Encoder{w: w}
+func NewEncoder(w io.Writer, plugins ...plugin) *Encoder {
+	e := &Encoder{w: w, contentPrefix: contentPrefix, attributePrefix: attrPrefix}
 	for _, p := range plugins {
-		e = p.AddTo(e)
+		e = p.AddToEncoder(e)
 	}
 	return e
 }
@@ -31,12 +31,6 @@ func (enc *Encoder) Encode(root *Node) error {
 	}
 	if root == nil {
 		return nil
-	}
-	if enc.contentPrefix == "" {
-		enc.contentPrefix = contentPrefix
-	}
-	if enc.attributePrefix == "" {
-		enc.attributePrefix = attrPrefix
 	}
 
 	enc.err = enc.format(root, 0)

--- a/encoder.go
+++ b/encoder.go
@@ -74,7 +74,7 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 			enc.write(label)
 			enc.write("\": ")
 
-			if len(children) > 1 {
+			if n.ChildrenAlwaysAsArray || len(children) > 1 {
 				// Array
 				enc.write("[")
 				for j, c := range children {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -2,6 +2,7 @@ package xml2json
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -98,4 +99,52 @@ func TestEncode(t *testing.T) {
 
 	enc.err = fmt.Errorf("Testing if error provided is returned")
 	assert.Error(enc.Encode(nil))
+}
+
+// TestEncodeWithChildrenAsExplicitArray ensures that ChildrenAlwaysAsArray flag works as expected.
+func TestEncodeWithChildrenAsExplicitArray(t *testing.T) {
+	type hobbies struct {
+		Hobbies []string `json:"hobbies"`
+	}
+
+	var (
+		testBio hobbies
+		err     error
+	)
+	assert := assert.New(t)
+
+	author := bio{
+		Hobbies: []string{"DJ"},
+	}
+
+	// ChildrenAlwaysAsArray is not set
+	root := &Node{}
+	for _, h := range author.Hobbies {
+		root.AddChild("hobbies", &Node{
+			Data: h,
+		})
+	}
+	var enc *Encoder
+
+	buf := new(bytes.Buffer)
+	enc = NewEncoder(buf)
+
+	err = enc.Encode(root)
+	assert.NoError(err)
+
+	json.Unmarshal(buf.Bytes(), &testBio)
+	assert.Equal(0, len(testBio.Hobbies))
+
+	// ChildrenAlwaysAsArray is set
+	root.ChildrenAlwaysAsArray = true
+	testBio = hobbies{}
+
+	buf = new(bytes.Buffer)
+	enc = NewEncoder(buf)
+
+	err = enc.Encode(root)
+	assert.NoError(err)
+
+	json.Unmarshal(buf.Bytes(), &testBio)
+	assert.Equal(1, len(testBio.Hobbies))
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -71,9 +71,9 @@ func TestEncode(t *testing.T) {
 	assert.NoError(err)
 
 	attr := WithAttrPrefix("test")
-	attr.AddTo(enc)
+	attr.AddToEncoder(enc)
 	content := WithContentPrefix("test2")
-	content.AddTo(enc)
+	content.AddToEncoder(enc)
 
 	err = enc.Encode(root)
 	assert.NoError(err)

--- a/jstype.go
+++ b/jstype.go
@@ -14,6 +14,7 @@ const (
 	Int
 	Float
 	String
+	Null
 )
 
 // Str2JSType extract a JavaScript type from a string
@@ -29,6 +30,8 @@ func Str2JSType(s string) JSType {
 		output = Float
 	case isInt(s):
 		output = Int
+	case isNull(s):
+		output = Null
 	default:
 		output = String // if all alternatives have been eliminated, the input is a string
 	}
@@ -64,4 +67,8 @@ func isInt(s string) bool {
 		}
 	}
 	return output
+}
+
+func isNull(s string) bool {
+	return s == "null"
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -9,21 +9,24 @@ import (
 )
 
 type Product struct {
-	ID      int     `json:"id"`
-	Price   float64 `json:"price"`
-	Deleted bool    `json:"deleted"`
+	ID       int         `json:"id"`
+	Price    float64     `json:"price"`
+	Deleted  bool        `json:"deleted"`
+	Nullable interface{} `json:"nullable"`
 }
 
 type StringProduct struct {
-	ID      string `json:"id"`
-	Price   string `json:"price"`
-	Deleted string `json:"deleted"`
+	ID       string `json:"id"`
+	Price    string `json:"price"`
+	Deleted  string `json:"deleted"`
+	Nullable string `json:"nullable"`
 }
 
 type MixedProduct struct {
-	ID      string  `json:"id"`
-	Price   float64 `json:"price"`
-	Deleted string  `json:"deleted"`
+	ID       string  `json:"id"`
+	Price    float64 `json:"price"`
+	Deleted  string  `json:"deleted"`
+	Nullable string  `json:"nullable"`
 }
 
 const (
@@ -32,19 +35,21 @@ const (
 		<id>42</id>
 		<price>13.32</price>
 		<deleted>true</deleted>
+		<nullable>null</nullable>
 		`
 )
 
 func TestAllJSTypeParsing(t *testing.T) {
 	xml := strings.NewReader(productString)
-	jsBuf, err := Convert(xml, WithTypeConverter(Bool, Int, Float))
+	jsBuf, err := Convert(xml, WithTypeConverter(Bool, Int, Float, Null))
 	assert.NoError(t, err, "could not parse test xml")
 	product := Product{}
 	err = json.Unmarshal(jsBuf.Bytes(), &product)
 	assert.NoError(t, err, "could not unmarshal test json")
-	assert.Equal(t, 42, product.ID, "price should match")
+	assert.Equal(t, 42, product.ID, "ID should match")
 	assert.Equal(t, 13.32, product.Price, "price should match")
-	assert.Equal(t, true, product.Deleted, "price should match")
+	assert.Equal(t, true, product.Deleted, "deleted should match")
+	assert.Equal(t, nil, product.Nullable, "nullable should match")
 }
 
 func TestStringParsing(t *testing.T) {
@@ -54,9 +59,10 @@ func TestStringParsing(t *testing.T) {
 	product := StringProduct{}
 	err = json.Unmarshal(jsBuf.Bytes(), &product)
 	assert.NoError(t, err, "could not unmarshal test json")
-	assert.Equal(t, "42", product.ID, "price should match")
+	assert.Equal(t, "42", product.ID, "ID should match")
 	assert.Equal(t, "13.32", product.Price, "price should match")
-	assert.Equal(t, "true", product.Deleted, "price should match")
+	assert.Equal(t, "true", product.Deleted, "deleted should match")
+	assert.Equal(t, "null", product.Nullable, "nullable should match")
 }
 
 func TestMixedParsing(t *testing.T) {
@@ -66,7 +72,8 @@ func TestMixedParsing(t *testing.T) {
 	product := MixedProduct{}
 	err = json.Unmarshal(jsBuf.Bytes(), &product)
 	assert.NoError(t, err, "could not unmarshal test json")
-	assert.Equal(t, "42", product.ID, "price should match")
+	assert.Equal(t, "42", product.ID, "ID should match")
 	assert.Equal(t, 13.32, product.Price, "price should match")
-	assert.Equal(t, "true", product.Deleted, "price should match")
+	assert.Equal(t, "true", product.Deleted, "deleted should match")
+	assert.Equal(t, "null", product.Nullable, "nullable should match")
 }

--- a/plugins.go
+++ b/plugins.go
@@ -5,9 +5,10 @@ import (
 )
 
 type (
-	// an encodePlugin is added to an encoder to allow custom functionality at runtime
-	encoderPlugin interface {
-		AddTo(*Encoder) *Encoder
+	// an plugin is added to an encoder or/and to an decoder to allow custom functionality at runtime
+	plugin interface {
+		AddToEncoder(*Encoder) *Encoder
+		AddToDecoder(*Decoder) *Decoder
 	}
 	// a type converter overides the default string sanitization for encoding json
 	encoderTypeConverter interface {
@@ -21,6 +22,22 @@ type (
 
 	attrPrefixer    string
 	contentPrefixer string
+
+	excluder []string
+
+	nodesFormatter struct {
+		list []nodeFormatter
+	}
+	nodeFormatter struct {
+		path   string
+		plugin nodePlugin
+	}
+
+	nodePlugin interface {
+		AddTo(*Node)
+	}
+
+	arrayFormatter struct{}
 )
 
 // WithTypeConverter allows customized js type conversion behavior by passing in the desired JSTypes
@@ -41,9 +58,13 @@ func (tc *customTypeConverter) parseAsString(t JSType) bool {
 }
 
 // Adds the type converter to the encoder
-func (tc *customTypeConverter) AddTo(e *Encoder) *Encoder {
+func (tc *customTypeConverter) AddToEncoder(e *Encoder) *Encoder {
 	e.tc = tc
 	return e
+}
+
+func (tc *customTypeConverter) AddToDecoder(d *Decoder) *Decoder {
+	return d
 }
 
 func (tc *customTypeConverter) Convert(s string) string {
@@ -65,8 +86,14 @@ func WithAttrPrefix(prefix string) *attrPrefixer {
 	return &ap
 }
 
-func (a *attrPrefixer) AddTo(e *Encoder) {
+func (a *attrPrefixer) AddToEncoder(e *Encoder) *Encoder {
 	e.attributePrefix = string((*a))
+	return e
+}
+
+func (a *attrPrefixer) AddToDecoder(d *Decoder) *Decoder {
+	d.attributePrefix = string((*a))
+	return d
 }
 
 // WithContentPrefix appends the given prefix to the json output of xml content fields to preserve namespaces
@@ -75,6 +102,60 @@ func WithContentPrefix(prefix string) *contentPrefixer {
 	return &c
 }
 
-func (c *contentPrefixer) AddTo(e *Encoder) {
+func (c *contentPrefixer) AddToEncoder(e *Encoder) *Encoder {
 	e.contentPrefix = string((*c))
+	return e
+}
+
+func (c *contentPrefixer) AddToDecoder(d *Decoder) *Decoder {
+	d.contentPrefix = string((*c))
+	return d
+}
+
+// ExcludeAttributes excludes some xml attributes, for example, xmlns:xsi, xsi:noNamespaceSchemaLocation
+func ExcludeAttributes(attrs []string) *excluder {
+	ex := excluder(attrs)
+	return &ex
+}
+
+func (ex *excluder) AddToEncoder(e *Encoder) *Encoder {
+	return e
+}
+
+func (ex *excluder) AddToDecoder(d *Decoder) *Decoder {
+	d.ExcludeAttributes([]string((*ex)))
+	return d
+}
+
+// WithNodes formats specific nodes
+func WithNodes(n ...nodeFormatter) *nodesFormatter {
+	return &nodesFormatter{list: n}
+}
+
+func (nf *nodesFormatter) AddToEncoder(e *Encoder) *Encoder {
+	return e
+}
+
+func (nf *nodesFormatter) AddToDecoder(d *Decoder) *Decoder {
+	d.AddFormatters(nf.list)
+	return d
+}
+
+func NodePlugin(path string, plugin nodePlugin) nodeFormatter {
+	return nodeFormatter{path: path, plugin: plugin}
+}
+
+func (nf *nodeFormatter) Format(node *Node) {
+	child := node.GetChild(nf.path)
+	if child != nil {
+		nf.plugin.AddTo(child)
+	}
+}
+
+func ToArray() *arrayFormatter {
+	return &arrayFormatter{}
+}
+
+func (af *arrayFormatter) AddTo(n *Node) {
+	n.ChildrenAlwaysAsArray = true
 }

--- a/struct.go
+++ b/struct.go
@@ -2,8 +2,9 @@ package xml2json
 
 // Node is a data element on a tree
 type Node struct {
-	Children map[string]Nodes
-	Data     string
+	Children              map[string]Nodes
+	Data                  string
+	ChildrenAlwaysAsArray bool
 }
 
 // Nodes is a list of nodes

--- a/struct.go
+++ b/struct.go
@@ -1,5 +1,9 @@
 package xml2json
 
+import (
+	"strings"
+)
+
 // Node is a data element on a tree
 type Node struct {
 	Children              map[string]Nodes
@@ -23,4 +27,21 @@ func (n *Node) AddChild(s string, c *Node) {
 // IsComplex returns whether it is a complex type (has children)
 func (n *Node) IsComplex() bool {
 	return len(n.Children) > 0
+}
+
+// GetChild returns child by path if exists. Path looks like "grandparent.parent.child.grandchild"
+func (n *Node) GetChild(path string) *Node {
+	result := n
+	names := strings.Split(path, ".")
+	for _, name := range names {
+		children, exists := result.Children[name]
+		if !exists {
+			return nil
+		}
+		if len(children) == 0 {
+			return nil
+		}
+		result = children[0]
+	}
+	return result
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -19,6 +19,18 @@ func TestAddChild(t *testing.T) {
 	assert.Len(n.Children, 2)
 }
 
+func TestGetChild(t *testing.T) {
+	assert := assert.New(t)
+
+	n := Node{}
+	child := Node{}
+	child.AddChild("b", &Node{Data: "foobar"})
+	n.AddChild("a", &child)
+
+	bNode := n.GetChild("a.b")
+	assert.Equal("foobar", bNode.Data)
+}
+
 func TestIsComplex(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Two features: 1) turning off attributes` names default prefixes; 2) excluding some attributes from decoder (for example, xmlns:xsi or xsi:noNamespaceSchemaLocation)

I use it so
```
	root := &xj.Node{}
	dec := xj.NewDecoder(strings.NewReader(doc))
	dec.TurnOffDefaultPrefixes()
	dec.ExcludeAttributes([]string{"xsi", "noNamespaceSchemaLocation"})
	dec.Decode(root)

	buf := new(bytes.Buffer)
	e := xj.NewEncoder(buf)
	e.Encode(root)

	fmt.Println(buf.String())
```

For the encoder added ChildrenAlwaysAsArray flag to has output like this

Input 
```
        <Corrections>
          <Correction Text="Not acceptable"/>
        </Corrections>
```

Output
```
"Corrections":{
  "Correction":[
    {
      "Text":"Not acceptable"
    }
  ]
}
```