### PR TITLE
Add support for JS type `Null`  (implements #20)

### DIFF
--- a/jstype.go
+++ b/jstype.go
@@ -14,6 +14,7 @@ const (
 	Int
 	Float
 	String
+	Null
 )
 
 // Str2JSType extract a JavaScript type from a string
@@ -29,6 +30,8 @@ func Str2JSType(s string) JSType {
 		output = Float
 	case isInt(s):
 		output = Int
+	case isNull(s):
+		output = Null
 	default:
 		output = String // if all alternatives have been eliminated, the input is a string
 	}
@@ -64,4 +67,13 @@ func isInt(s string) bool {
 		}
 	}
 	return output
+}
+
+func isNull(s string) bool {
+	switch strings.ToLower(s) {
+		case "", "null", "nil" :
+			return true
+		default :
+			return false
+	}
 }

--- a/plugins.go
+++ b/plugins.go
@@ -52,7 +52,9 @@ func (tc *customTypeConverter) Convert(s string) string {
 		s = s[1 : len(s)-1]
 	}
 	jsType := Str2JSType(s)
-	if tc.parseAsString(jsType) {
+	if jsType == Null {
+		s = "null"
+	} else if tc.parseAsString(jsType) {
 		// add the quotes removed at the start of this func
 		s = `"` + s + `"`
 	}


### PR DESCRIPTION
This small patch add support for a new JS type `Null` which accepts the following values as JSON `null`:
* the empty string;
* the `null` and `nil` strings;
* any case-variant of the above;

(Implements #20)
