### PR TITLE
Fixes managemement of ToArray plugin

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -67,7 +67,14 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 			enc.write(label)
 			enc.write("\": ")
 
-			if n.ChildrenAlwaysAsArray || len(children) > 1 {
+			wrapIntoArray := false
+			for _, cchild := range children {
+				if cchild.ChildrenAlwaysAsArray {
+					wrapIntoArray = true
+				}
+			}
+
+			if wrapIntoArray || len(children) > 1 {
 				// Array
 				enc.write("[")
 				for j, c := range children {
@@ -79,6 +86,7 @@ func (enc *Encoder) format(n *Node, lvl int) error {
 				}
 				enc.write("]")
 			} else {
+
 				// Map
 				enc.format(children[0], lvl+1)
 			}

--- a/plugins.go
+++ b/plugins.go
@@ -146,9 +146,11 @@ func NodePlugin(path string, plugin nodePlugin) nodeFormatter {
 }
 
 func (nf *nodeFormatter) Format(node *Node) {
-	child := node.GetChild(nf.path)
-	if child != nil {
-		nf.plugin.AddTo(child)
+	children := node.GetChildren(nf.path)
+	if children != nil {
+		for _, child := range children {
+			nf.plugin.AddTo(child)
+		}
 	}
 }
 

--- a/struct.go
+++ b/struct.go
@@ -45,3 +45,31 @@ func (n *Node) GetChild(path string) *Node {
 	}
 	return result
 }
+
+// GetChildren returns a slice of Children for a given path
+func (n *Node) GetChildren(path string) []*Node {
+	pathtok := strings.Split(path, ".")
+	return n.getChildren(pathtok)
+}
+
+func (n *Node) getChildren(pt []string) []*Node {
+	var result []*Node
+	name := pt[0]
+
+	children, exists := n.Children[name]
+	if !exists {
+		return nil
+	}
+	if len(children) == 0 {
+		return nil
+	}
+	if len(pt) > 1 {
+		for _, child := range children {
+			result = append(result, child.getChildren(pt[1:])...)
+		}
+	} else {
+		result = append(result, children...)
+	}
+
+	return result
+}


### PR DESCRIPTION
1. Looks up every path not just first
2. Indicates the child not the parent for which you want to wrap into array (allows selectivity).